### PR TITLE
Define PAUSE_IN in any case

### DIFF
--- a/include/mutexee_in.h
+++ b/include/mutexee_in.h
@@ -116,9 +116,10 @@ extern "C" {
 
 #if defined(PAUSE_IN)
 #  undef PAUSE_IN
+#endif
 #  define PAUSE_IN()				\
   asm volatile ("mfence");
-#endif
+
 
   static inline void
   mutexee_cdelay(const int cycles)


### PR DESCRIPTION
Currently, if PAUSE_IN is not defined (e.g., if we don't use the build system), then it will never be.
